### PR TITLE
fix: added node_id to style model

### DIFF
--- a/lib/src/models/style.dart
+++ b/lib/src/models/style.dart
@@ -11,6 +11,10 @@ part 'style.g.dart';
 @JsonSerializable()
 @CopyWith()
 class Style extends Equatable {
+  /// The node id of this style.
+  @JsonKey(name: 'node_id')
+  final String? nodeId;
+
   /// The key of the style.
   final String? key;
 
@@ -25,6 +29,7 @@ class Style extends Equatable {
   final StyleType? type;
 
   Style({
+    this.nodeId,
     this.key,
     this.name,
     this.description,
@@ -33,6 +38,7 @@ class Style extends Equatable {
 
   @override
   List<Object?> get props => [
+        nodeId,
         key,
         name,
         description,

--- a/lib/src/models/style.g.dart
+++ b/lib/src/models/style.g.dart
@@ -7,6 +7,8 @@ part of 'style.dart';
 // **************************************************************************
 
 abstract class _$StyleCWProxy {
+  Style nodeId(String? nodeId);
+
   Style key(String? key);
 
   Style name(String? name);
@@ -22,6 +24,7 @@ abstract class _$StyleCWProxy {
   /// Style(...).copyWith(id: 12, name: "My name")
   /// ````
   Style call({
+    String? nodeId,
     String? key,
     String? name,
     String? description,
@@ -34,6 +37,9 @@ class _$StyleCWProxyImpl implements _$StyleCWProxy {
   const _$StyleCWProxyImpl(this._value);
 
   final Style _value;
+
+  @override
+  Style nodeId(String? nodeId) => this(nodeId: nodeId);
 
   @override
   Style key(String? key) => this(key: key);
@@ -56,12 +62,17 @@ class _$StyleCWProxyImpl implements _$StyleCWProxy {
   /// Style(...).copyWith(id: 12, name: "My name")
   /// ````
   Style call({
+    Object? nodeId = const $CopyWithPlaceholder(),
     Object? key = const $CopyWithPlaceholder(),
     Object? name = const $CopyWithPlaceholder(),
     Object? description = const $CopyWithPlaceholder(),
     Object? type = const $CopyWithPlaceholder(),
   }) {
     return Style(
+      nodeId: nodeId == const $CopyWithPlaceholder()
+          ? _value.nodeId
+          // ignore: cast_nullable_to_non_nullable
+          : nodeId as String?,
       key: key == const $CopyWithPlaceholder()
           ? _value.key
           // ignore: cast_nullable_to_non_nullable
@@ -93,6 +104,7 @@ extension $StyleCopyWith on Style {
 // **************************************************************************
 
 Style _$StyleFromJson(Map<String, dynamic> json) => Style(
+      nodeId: json['node_id'] as String?,
       key: json['key'] as String?,
       name: json['name'] as String?,
       description: json['description'] as String?,
@@ -100,6 +112,7 @@ Style _$StyleFromJson(Map<String, dynamic> json) => Style(
     );
 
 Map<String, dynamic> _$StyleToJson(Style instance) => <String, dynamic>{
+      'node_id': instance.nodeId,
       'key': instance.key,
       'name': instance.name,
       'description': instance.description,


### PR DESCRIPTION
The current `Style` does not include the node ID, which means styles can not be matched against their actual nodes (making them completely unusable since the nodes contain the content of the style).

This PR fixes that :)