### PR TITLE
fix!: use `Node` instead of `Document` in `FileResponse`

### DIFF
--- a/lib/src/models/service/file_response.dart
+++ b/lib/src/models/service/file_response.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:figma/src/converters/converters.dart';
 import 'package:figma/src/models.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
@@ -25,7 +26,8 @@ class FileResponse extends Equatable {
   final String? version;
 
   /// File document (top-level node).
-  final Document? document;
+  @NodeJsonConverter()
+  final Node? document;
 
   /// File components, if any.
   final Map<String, Component>? components;

--- a/lib/src/models/service/file_response.g.dart
+++ b/lib/src/models/service/file_response.g.dart
@@ -17,7 +17,7 @@ abstract class _$FileResponseCWProxy {
 
   FileResponse version(String? version);
 
-  FileResponse document(Document? document);
+  FileResponse document(Node? document);
 
   FileResponse components(Map<String, Component>? components);
 
@@ -39,7 +39,7 @@ abstract class _$FileResponseCWProxy {
     DateTime? lastModified,
     String? thumbnailUrl,
     String? version,
-    Document? document,
+    Node? document,
     Map<String, Component>? components,
     Map<String, ComponentSet>? componentSets,
     int? schemaVersion,
@@ -71,7 +71,7 @@ class _$FileResponseCWProxyImpl implements _$FileResponseCWProxy {
   FileResponse version(String? version) => this(version: version);
 
   @override
-  FileResponse document(Document? document) => this(document: document);
+  FileResponse document(Node? document) => this(document: document);
 
   @override
   FileResponse components(Map<String, Component>? components) =>
@@ -132,7 +132,7 @@ class _$FileResponseCWProxyImpl implements _$FileResponseCWProxy {
       document: document == const $CopyWithPlaceholder()
           ? _value.document
           // ignore: cast_nullable_to_non_nullable
-          : document as Document?,
+          : document as Node?,
       components: components == const $CopyWithPlaceholder()
           ? _value.components
           // ignore: cast_nullable_to_non_nullable
@@ -171,9 +171,7 @@ FileResponse _$FileResponseFromJson(Map<String, dynamic> json) => FileResponse(
           : DateTime.parse(json['lastModified'] as String),
       thumbnailUrl: json['thumbnailUrl'] as String?,
       version: json['version'] as String?,
-      document: json['document'] == null
-          ? null
-          : Document.fromJson(json['document'] as Map<String, dynamic>),
+      document: const NodeJsonConverter().fromJson(json['document']),
       components: (json['components'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, Component.fromJson(e as Map<String, dynamic>)),
       ),
@@ -193,7 +191,7 @@ Map<String, dynamic> _$FileResponseToJson(FileResponse instance) =>
       'lastModified': instance.lastModified?.toIso8601String(),
       'thumbnailUrl': instance.thumbnailUrl,
       'version': instance.version,
-      'document': instance.document,
+      'document': const NodeJsonConverter().toJson(instance.document),
       'components': instance.components,
       'componentSets': instance.componentSets,
       'schemaVersion': instance.schemaVersion,


### PR DESCRIPTION
I'm not quite sure whether this is the right place to make this adjustment.

The problem I ran into is that `NodesResponse.nodes` contains `FileResponse`s as values. `FileResponse` then contains the nodes that I wanted to access using `getFileNodes`, however it looses all the content of the actual Nodes if its Type is `Document`, since it could contain any kind of node at this point.

More concretely, I wanted to fetch all styles in a file using `getFileStyles` and then use their `nodeId` (see PR #27 for that problem) to fetch the actual style content using `getFileNodes`. The response I get however assumes the returned styles are Documents, while they are actually `Text`, `Rectangle`, e.t.c.

This PR fixes that, however it might be smarter not to use `FileResponse` but a new `Response` class  in `NodeResponse.nodes`, I'm looking forward to your input on that one!