### PR TITLE
models: add fontVariations enum

### DIFF
--- a/lib/src/models/local_variable.g.dart
+++ b/lib/src/models/local_variable.g.dart
@@ -258,6 +258,7 @@ const _$VariableScopeEnumMap = {
   VariableScope.textFill: 'TEXT_FILL',
   VariableScope.strokeColor: 'STROKE_COLOR',
   VariableScope.effectColor: 'EFFECT_COLOR',
+  VariableScope.fontVariations: 'FONT_VARIATIONS',
 };
 
 const _$VariableCodeSyntaxPlatformEnumMap = {

--- a/lib/src/models/variable_scope.dart
+++ b/lib/src/models/variable_scope.dart
@@ -43,4 +43,6 @@ enum VariableScope {
   strokeColor,
   @JsonValue('EFFECT_COLOR')
   effectColor,
+  @JsonValue('FONT_VARIATIONS')
+  fontVariations,
 }


### PR DESCRIPTION
The OpenAPI definition of VariableScope added `FONT_VARIATIONS` so include it in the enum and regenerate sources.