### PR TITLE
Export `EffectType` from `models.dart`

### DIFF
--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -17,7 +17,7 @@ export 'models/counter_axis_align_items.dart';
 export 'models/counter_axis_sizing_mode.dart';
 export 'models/document.dart' show Document;
 export 'models/easing_type.dart';
-export 'models/effect.dart' show Effect;
+export 'models/effect.dart' show Effect, EffectType;
 export 'models/ellipse.dart' show Ellipse;
 export 'models/export_setting.dart' show ExportSetting;
 export 'models/flow_starting_point.dart' show FlowStartingPoint;

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -91,7 +91,8 @@ export 'models/stroke_weights.dart' show StrokeWeights;
 export 'models/style.dart' show Style;
 export 'models/style_type.dart';
 export 'models/text.dart' show Text;
-export 'models/type_style.dart' show TypeStyle;
+export 'models/type_style.dart'
+    show TypeStyle, TextDecoration, TextAlignVertical, TextAlignHorizontal;
 export 'models/user.dart' show User;
 export 'models/variable_code_syntax_platform.dart';
 export 'models/variable_scope.dart';


### PR DESCRIPTION
The latest update broke the external interface by removing the `EffectType` enum from the export directive inside `models.dart` file.
I suggest to export `EffectType` as it is pretty useful. I'm currently using to do some magic inside https://github.com/intales/morphr 😅

Thank you for this awesome library, I hope this PR is helpful!