### PR TITLE
client: use proxy to determine default for http2

### DIFF
--- a/lib/src/client/browser.dart
+++ b/lib/src/client/browser.dart
@@ -1,0 +1,3 @@
+import 'shared.dart';
+
+final SendRequest? http2 = null;

--- a/lib/src/client/io.dart
+++ b/lib/src/client/io.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http2/http2.dart';
+
+import 'shared.dart';
+
+final SendRequest? http2 =
+    HttpClient.findProxyFromEnvironment(Uri.https(base)) == 'DIRECT'
+        ? _http2
+        : null;
+
+Future<Response> _http2(
+  String method,
+  Uri uri,
+  Map<String, String> headers, [
+  String? body,
+]) async {
+  final transport = ClientTransportConnection.viaSocket(
+    await SecureSocket.connect(
+      uri.host,
+      uri.port,
+      supportedProtocols: ['h2'],
+    ),
+  );
+
+  final stream = transport.makeRequest(
+    [
+      Header.ascii(':method', method),
+      Header.ascii(':path', uri.path + (uri.hasQuery ? '?${uri.query}' : '')),
+      Header.ascii(':scheme', uri.scheme),
+      Header.ascii(':authority', uri.host),
+      ...headers.entries.map(
+        (e) => Header.ascii(e.key.toLowerCase(), e.value),
+      ),
+    ],
+    endStream: body == null,
+  );
+
+  if (body != null) {
+    stream.sendData(utf8.encode(body), endStream: true);
+  }
+
+  var status = 200;
+  final buffer = <int>[];
+
+  await for (final message in stream.incomingMessages) {
+    if (message is HeadersStreamMessage) {
+      for (final header in message.headers) {
+        final name = utf8.decode(header.name);
+        final value = utf8.decode(header.value);
+        if (name == ':status') {
+          status = int.parse(value);
+        }
+      }
+    } else if (message is DataStreamMessage) {
+      buffer.addAll(message.bytes);
+    }
+  }
+
+  await transport.finish();
+
+  return Response(status, utf8.decode(buffer));
+}

--- a/lib/src/client/shared.dart
+++ b/lib/src/client/shared.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'package:http/http.dart';
+
+typedef SendRequest = Future<Response> Function(
+  String method,
+  Uri uri,
+  Map<String, String> headers, [
+  String? body,
+]);
+
+/// Figma API base URL.
+const String base = 'api.figma.com';
+
+class Response {
+  final int statusCode;
+  final String body;
+
+  const Response(this.statusCode, this.body);
+}
+
+Future<Response> http(
+  String method,
+  Uri uri,
+  Map<String, String> headers, [
+  String? body,
+]) async {
+  final client = Client();
+  try {
+    final request = Request(method, uri)
+      ..headers.addAll(headers)
+      ..body = body ?? '';
+    final response = await client.send(request);
+    final responseBody = await response.stream.toBytes();
+    return Response(response.statusCode, utf8.decode(responseBody));
+  } finally {
+    client.close();
+  }
+}

--- a/lib/src/client/stub.dart
+++ b/lib/src/client/stub.dart
@@ -1,0 +1,4 @@
+import 'shared.dart';
+
+SendRequest? get http2 => throw UnsupportedError(
+    'cannot determine http2 support without dart:js_interop or dart:io');


### PR DESCRIPTION
The current implementation of HTTP/2 does not handle proxy servers. Use `HttpClient.findProxyFromEnvironment` to see if a request to Figma would be proxied.

Refactor the `FigmaClient` so the `_send` method is now a function pointer. Use conditional imports to handle the lack of HTTP/2 in the browser by exposing a getter for a `http2` implementation. On browser it always returns `null` but in `io` if a proxy is not used it returns the HTTP2 implementation.
