### PR TITLE
example: cleanup async code in icons

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,3 +11,6 @@ linter:
     - unnecessary_await_in_return
     - unnecessary_lambdas
     - cascade_invocations
+    - avoid_slow_async_io
+    - unnecessary_async
+    - unawaited_futures

--- a/example/icons.dart
+++ b/example/icons.dart
@@ -37,7 +37,7 @@ Future<void> optimize(Directory dir) async {
     throw Exception('SVGO not found in path, skipping optimization');
   }
 
-  final list = dir.listSync();
+  final list = await dir.list().toList();
 
   // Optimize SVGs.
   final svgoFutures = <Future>[];
@@ -49,7 +49,7 @@ Future<void> optimize(Directory dir) async {
   }
 
   // Execute SVGO in parallel.
-  Future.wait(svgoFutures).then((_) {
+  return Future.wait(svgoFutures).then((_) {
     print('Optimized ${svgoFutures.length} icons');
   });
 }
@@ -141,11 +141,11 @@ Future<void> download(
 
         // Create file if it doesn't exist.
         if (!file.existsSync()) {
-          file.createSync(recursive: true);
+          await file.create(recursive: true);
         }
 
         // Write SVG contents to file.
-        file.writeAsStringSync(svgRes.body);
+        await file.writeAsString(svgRes.body);
       }
     });
 
@@ -153,7 +153,7 @@ Future<void> download(
   }
 
   // Execute requests in parallel.
-  await Future.wait(futures).then((_) async {
+  return Future.wait(futures).then((_) {
     print('Saved ${res.images!.length} icons');
   });
 }
@@ -174,15 +174,17 @@ Future<void> generateIconFont(
         'icon_font_generator not found in path, skipping font generation');
   }
 
-  if (!File(dartOut).existsSync()) {
-    File(dartOut).createSync(recursive: true);
+  final dartFile = File(dartOut);
+  if (!dartFile.existsSync()) {
+    await dartFile.create(recursive: true);
   }
 
-  if (!File(ttfOut).existsSync()) {
-    File(ttfOut).createSync(recursive: true);
+  final ttfFile = File(ttfOut);
+  if (!ttfFile.existsSync()) {
+    await ttfFile.create(recursive: true);
   }
 
-  Process.run('icon_font_generator', [
+  return Process.run('icon_font_generator', [
     '--from=${dir.path}',
     '--class-name=$className',
     '--out-font=$ttfOut',


### PR DESCRIPTION
Modify the code to abide by the `unnecessary_async` and `unawaited_futures` linter rules. Use aysnc io calls minus those called out in the `avoid_slow_async_io` rule.