### PR TITLE
ci: enforce lints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,8 @@ jobs:
       - name: Install dependencies
         run: dart pub get
 
-      - name: Analyze library
-        run: dart analyze lib
-
-      - name: Analyze tests
-        run: dart analyze test
+      - name: Analyze package
+        run: dart analyze --fatal-infos
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Run `dart analyze` with `--fatal-infos` to prevent linter violations from entering the codebase. Run on the root since some lints are run on the pubspec file as well.