### PR TITLE
ci: split testing types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,22 @@ jobs:
 
       - name: Run tests
         run: dart test
+
+  integration-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: beta
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Run tests
+        run: dart test -P integration
         env:
           FIGMA_TEST_FILE: ${{ secrets.FIGMA_TEST_FILE }}
           FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,11 @@
+tags:
+  # Integration tests can take a long time to complete
+  integration:
+    timeout: 2m
+
+presets:
+  integration:
+    include_tags: integration
+
+# By default ignore integration tests since they require environmental setup
+exclude_tags: integration

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -1,3 +1,6 @@
+@Tags(['integration'])
+library;
+
 import 'dart:io';
 
 import 'package:figma/figma.dart';


### PR DESCRIPTION
Use a `dart_test.yaml` to define the defaults for `dart test`.

Tag `integration_test.dart` as `integration`. The tests can only be run by specifying `-P integration`. This is because they require additional setup to run successfully.

Add a separate workflow for integration testing so the workflow can be marked as optional since it will fail if the access token expires.