### PR TITLE
tool: output Dart source code

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dev_dependencies:
   cli_util: ^0.4.2
   code_builder: ^4.11.1
   copy_with_extension_gen: ">=10.0.0 <13.0.0"
+  dart_style: ^3.1.3
   json_serializable: ^6.11.1
   lints: ^6.0.0
   logging: ^1.3.0

--- a/tool/generate_models.dart
+++ b/tool/generate_models.dart
@@ -2,29 +2,21 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+import 'src/generate.dart';
 import 'src/io.dart';
-import 'src/logging.dart';
-import 'src/parse.dart';
-import 'src/schema.dart';
 
 Future<void> main() async {
-  final logger = setupLogger();
-
   final packageRoot = p.dirname(p.dirname(Platform.script.path));
-
-  // Load specification
   final specPath = p.join(packageRoot, 'tool', 'openapi', 'openapi.yaml');
-  final loadProgress = logger.progress(
-    'Loading OpenAPI specification from $specPath',
-  );
-  final document = await loadYamlFile(specPath);
-  final info = document.info;
-  loadProgress.finish(message: 'Loaded v${info.version} of "${info.title}"');
+  final outputPath = p.join(packageRoot, 'lib', 'src', 'models');
 
-  // Parse schema definition
-  final parsingProgress = logger.progress(
-    'Parsing OpenAPI specification from $specPath',
+  final typeNames = await loadTypeListing(
+    p.join(packageRoot, 'tool', 'types.txt'),
   );
-  final definitions = parseSchemaDefinitions(document).toList();
-  parsingProgress.finish(message: 'Parsed ${definitions.length} definitions');
+
+  return generate(
+    specPath,
+    outputPath,
+    generateCheck: (definition) => typeNames.contains(definition.name),
+  );
 }

--- a/tool/src/generate.dart
+++ b/tool/src/generate.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'hierarchy.dart';
+import 'io.dart';
+import 'json_map.dart';
+import 'logging.dart';
+import 'parse.dart';
+import 'reference.dart';
+import 'schema.dart';
+import 'spec.dart';
+
+/// Generate sources from an OpenAPI specification.
+///
+/// An YAML file containing the definition is expected at [specPath] and the
+/// sources are written to [outputPath].
+///
+/// A [logLevel] can be provided to control the log level.
+///
+/// A [preprocessSchema] function can modify the schema before it is parsed
+/// into types.
+///
+/// A [mixinCheck] function can be provided to flag certain types as mixins.
+///
+/// A [generateCheck] function can be provided to limit the types being
+/// generated, acting as an allowlist.
+Future<void> generate(
+  String specPath,
+  String outputPath, {
+  String? logLevel,
+  void Function(JsonMap)? preprocessSchema,
+  bool Function(TypeDefinition)? mixinCheck,
+  bool Function(TypeDefinition)? generateCheck,
+}) async {
+  final logger = setupLogger(level: logLevel);
+
+  final loadProgress = logger.progress('Loading OpenAPI specification');
+  final document = await loadYamlFile(specPath);
+  final info = document.info;
+  final apiVersion = info.version;
+  final apiTitle = info.title;
+  loadProgress.finish(
+    message: 'Loaded v$apiVersion of "$apiTitle" from $specPath',
+  );
+
+  if (preprocessSchema != null) {
+    final preprocessProgress = logger.progress(
+      'Preprocessing OpenAPI specification',
+    );
+    preprocessSchema(document);
+    preprocessProgress.finish(message: 'Preprocessing completed');
+  }
+
+  // Parse schema definition
+  final parsingProgress = logger.progress('Parsing OpenAPI specification');
+  final definitions = parseSchemaDefinitions(document).toList();
+  parsingProgress.finish(message: 'Parsed ${definitions.length} definitions');
+
+  // Generate source code
+  if (mixinCheck != null) {
+    ClassHierarchy.mixinCheck = mixinCheck;
+  }
+
+  final generatedComment = 'Generated from v$apiVersion of "$apiTitle"';
+  final tasks = <Future>[];
+
+  final generateDefinitions = generateCheck != null
+      ? definitions.where(generateCheck)
+      : definitions;
+
+  final generationProcess = logger.progress('Generating OpenAPI specification');
+  for (final definition in generateDefinitions) {
+    print('generating spec for ${definition.name}');
+    final library = librarySpec(definition, comment: generatedComment);
+    print('generating source for ${definition.name}');
+    final source = librarySource(library);
+    final filePath = p.join(outputPath, definition.dartFile!);
+    print('writing source for ${definition.name} at $filePath');
+
+    tasks.add(File(filePath).writeAsString(source));
+  }
+  final files = await Future.wait(tasks);
+  generationProcess.finish(message: 'Generated ${files.length} libraries');
+}

--- a/tool/src/io.dart
+++ b/tool/src/io.dart
@@ -6,11 +6,23 @@ import 'json_map.dart';
 
 /// Load a YAML file from the [path].
 Future<JsonMap> loadYamlFile(String path) async {
-  final file = File(path);
-  final contents = await file.readAsString();
+  final contents = await _fileContents(path);
 
   return _deepCloneJsonMap(loadYaml(contents) as Map);
 }
+
+/// Load a text file containing a listing of types to generate from the [path].
+Future<List<String>> loadTypeListing(String path) async {
+  final contents = await _fileContents(path);
+
+  return contents
+      .split('\n')
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty && !s.startsWith('#'))
+      .toList();
+}
+
+Future<String> _fileContents(String path) => File(path).readAsString();
 
 /// Perform a deep clone of the [map].
 ///

--- a/tool/src/spec.dart
+++ b/tool/src/spec.dart
@@ -1,11 +1,27 @@
 import 'package:code_builder/code_builder.dart' as code;
 import 'package:collection/collection.dart';
+import 'package:dart_style/dart_style.dart';
 
 import 'annotate.dart' as annotate;
 import 'documentation.dart';
 import 'hierarchy.dart';
 import 'parse.dart';
 import 'reference.dart' as reference;
+
+final DartFormatter _formatter = DartFormatter(
+  languageVersion: DartFormatter.latestLanguageVersion,
+);
+
+/// Generate source code from the [library].
+String librarySource(code.Library library) {
+  final emitter = code.DartEmitter(
+    allocator: code.Allocator(),
+    orderDirectives: true,
+    useNullSafetySyntax: true,
+  );
+
+  return _formatter.format('${library.accept(emitter)}');
+}
 
 /// Create a [code.Library] from the [definition].
 code.Library librarySpec(TypeDefinition definition, {String? comment}) {


### PR DESCRIPTION
Create a `generate` function to orchestrate the code generation.

Load a listing of types to generate from.