### PR TITLE
models: add missing TextCase enumeration

### DIFF
--- a/lib/src/models/text_case.dart
+++ b/lib/src/models/text_case.dart
@@ -4,6 +4,8 @@ import 'package:json_annotation/json_annotation.dart';
 
 /// Text casing applied to the node, default is the original casing.
 enum TextCase {
+  @JsonValue('ORIGINAL')
+  original,
   @JsonValue('UPPER')
   upper,
   @JsonValue('LOWER')

--- a/lib/src/models/text_path_type_style.g.dart
+++ b/lib/src/models/text_path_type_style.g.dart
@@ -328,6 +328,7 @@ Map<String, dynamic> _$TextPathTypeStyleToJson(
 };
 
 const _$TextCaseEnumMap = {
+  TextCase.original: 'ORIGINAL',
   TextCase.upper: 'UPPER',
   TextCase.lower: 'LOWER',
   TextCase.title: 'TITLE',

--- a/lib/src/models/type_style.g.dart
+++ b/lib/src/models/type_style.g.dart
@@ -493,6 +493,7 @@ Map<String, dynamic> _$TypeStyleToJson(TypeStyle instance) => <String, dynamic>{
 };
 
 const _$TextCaseEnumMap = {
+  TextCase.original: 'ORIGINAL',
   TextCase.upper: 'UPPER',
   TextCase.lower: 'LOWER',
   TextCase.title: 'TITLE',


### PR DESCRIPTION
Add the `ORIGINAL` value, mapped to `TextCase.original`, to the enumeration.