### PR TITLE
models: add missing bound variables

### DIFF
--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -25,6 +25,7 @@ export 'models/component_node.dart';
 export 'models/component_properties_trait.dart';
 export 'models/component_property.dart';
 export 'models/component_property_definition.dart';
+export 'models/component_property_definition_variables.dart';
 export 'models/component_property_type.dart';
 export 'models/component_property_variables.dart';
 export 'models/component_response.dart';

--- a/lib/src/models/component_property_definition.dart
+++ b/lib/src/models/component_property_definition.dart
@@ -5,6 +5,7 @@ import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 
+import 'component_property_definition_variables.dart';
 import 'component_property_type.dart';
 import 'instance_swap_preferred_value.dart';
 
@@ -20,6 +21,7 @@ class ComponentPropertyDefinition extends Equatable {
     required this.defaultValue,
     this.variantOptions = const [],
     this.preferredValues = const [],
+    this.boundVariables = const ComponentPropertyDefinitionVariables(),
   });
 
   factory ComponentPropertyDefinition.fromJson(Map<String, Object?> json) =>
@@ -43,12 +45,16 @@ class ComponentPropertyDefinition extends Equatable {
   @JsonKey(defaultValue: [])
   final List<InstanceSwapPreferredValue> preferredValues;
 
+  /// The variables bound to a particular field on this component property.
+  final ComponentPropertyDefinitionVariables boundVariables;
+
   @override
   List<Object?> get props => <Object?>[
     type,
     defaultValue,
     variantOptions,
     preferredValues,
+    boundVariables,
   ];
 
   Map<String, Object?> toJson() => _$ComponentPropertyDefinitionToJson(this);

--- a/lib/src/models/component_property_definition.g.dart
+++ b/lib/src/models/component_property_definition.g.dart
@@ -17,6 +17,10 @@ abstract class _$ComponentPropertyDefinitionCWProxy {
     List<InstanceSwapPreferredValue> preferredValues,
   );
 
+  ComponentPropertyDefinition boundVariables(
+    ComponentPropertyDefinitionVariables boundVariables,
+  );
+
   /// Creates a new instance with the provided field values.
   /// Passing `null` to a nullable field nullifies it, while `null` for a non-nullable field is ignored. To update a single field use `ComponentPropertyDefinition(...).copyWith.fieldName(value)`.
   ///
@@ -29,6 +33,7 @@ abstract class _$ComponentPropertyDefinitionCWProxy {
     Object defaultValue,
     List<String> variantOptions,
     List<InstanceSwapPreferredValue> preferredValues,
+    ComponentPropertyDefinitionVariables boundVariables,
   });
 }
 
@@ -58,6 +63,11 @@ class _$ComponentPropertyDefinitionCWProxyImpl
   ) => call(preferredValues: preferredValues);
 
   @override
+  ComponentPropertyDefinition boundVariables(
+    ComponentPropertyDefinitionVariables boundVariables,
+  ) => call(boundVariables: boundVariables);
+
+  @override
   /// Creates a new instance with the provided field values.
   /// Passing `null` to a nullable field nullifies it, while `null` for a non-nullable field is ignored. To update a single field use `ComponentPropertyDefinition(...).copyWith.fieldName(value)`.
   ///
@@ -70,6 +80,7 @@ class _$ComponentPropertyDefinitionCWProxyImpl
     Object? defaultValue = const $CopyWithPlaceholder(),
     Object? variantOptions = const $CopyWithPlaceholder(),
     Object? preferredValues = const $CopyWithPlaceholder(),
+    Object? boundVariables = const $CopyWithPlaceholder(),
   }) {
     return ComponentPropertyDefinition(
       type: type == const $CopyWithPlaceholder() || type == null
@@ -93,6 +104,12 @@ class _$ComponentPropertyDefinitionCWProxyImpl
           ? _value.preferredValues
           // ignore: cast_nullable_to_non_nullable
           : preferredValues as List<InstanceSwapPreferredValue>,
+      boundVariables:
+          boundVariables == const $CopyWithPlaceholder() ||
+              boundVariables == null
+          ? _value.boundVariables
+          // ignore: cast_nullable_to_non_nullable
+          : boundVariables as ComponentPropertyDefinitionVariables,
     );
   }
 }
@@ -127,6 +144,11 @@ ComponentPropertyDefinition _$ComponentPropertyDefinitionFromJson(
           )
           .toList() ??
       [],
+  boundVariables: json['boundVariables'] == null
+      ? const ComponentPropertyDefinitionVariables()
+      : ComponentPropertyDefinitionVariables.fromJson(
+          json['boundVariables'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$ComponentPropertyDefinitionToJson(
@@ -136,6 +158,7 @@ Map<String, dynamic> _$ComponentPropertyDefinitionToJson(
   'defaultValue': instance.defaultValue,
   'variantOptions': instance.variantOptions,
   'preferredValues': instance.preferredValues.map((e) => e.toJson()).toList(),
+  'boundVariables': instance.boundVariables.toJson(),
 };
 
 const _$ComponentPropertyTypeEnumMap = {

--- a/lib/src/models/component_property_definition_variables.dart
+++ b/lib/src/models/component_property_definition_variables.dart
@@ -1,0 +1,31 @@
+// Generated from v0.36.0 of the Figma REST API specification
+
+import 'package:copy_with_extension/copy_with_extension.dart';
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
+
+import 'variable_alias.dart';
+
+part 'component_property_definition_variables.g.dart';
+
+/// The variables bound to a particular field on this component property.
+@JsonSerializable(explicitToJson: true)
+@CopyWith()
+@immutable
+class ComponentPropertyDefinitionVariables extends Equatable {
+  const ComponentPropertyDefinitionVariables({this.defaultValue});
+
+  factory ComponentPropertyDefinitionVariables.fromJson(
+    Map<String, Object?> json,
+  ) => _$ComponentPropertyDefinitionVariablesFromJson(json);
+
+  @JsonKey(includeIfNull: false)
+  final VariableAlias? defaultValue;
+
+  @override
+  List<Object?> get props => <Object?>[defaultValue];
+
+  Map<String, Object?> toJson() =>
+      _$ComponentPropertyDefinitionVariablesToJson(this);
+}

--- a/lib/src/models/component_property_definition_variables.g.dart
+++ b/lib/src/models/component_property_definition_variables.g.dart
@@ -1,0 +1,82 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'component_property_definition_variables.dart';
+
+// **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$ComponentPropertyDefinitionVariablesCWProxy {
+  ComponentPropertyDefinitionVariables defaultValue(
+    VariableAlias? defaultValue,
+  );
+
+  /// Creates a new instance with the provided field values.
+  /// Passing `null` to a nullable field nullifies it, while `null` for a non-nullable field is ignored. To update a single field use `ComponentPropertyDefinitionVariables(...).copyWith.fieldName(value)`.
+  ///
+  /// Example:
+  /// ```dart
+  /// ComponentPropertyDefinitionVariables(...).copyWith(id: 12, name: "My name")
+  /// ```
+  ComponentPropertyDefinitionVariables call({VariableAlias? defaultValue});
+}
+
+/// Callable proxy for `copyWith` functionality.
+/// Use as `instanceOfComponentPropertyDefinitionVariables.copyWith(...)` or call `instanceOfComponentPropertyDefinitionVariables.copyWith.fieldName(value)` for a single field.
+class _$ComponentPropertyDefinitionVariablesCWProxyImpl
+    implements _$ComponentPropertyDefinitionVariablesCWProxy {
+  const _$ComponentPropertyDefinitionVariablesCWProxyImpl(this._value);
+
+  final ComponentPropertyDefinitionVariables _value;
+
+  @override
+  ComponentPropertyDefinitionVariables defaultValue(
+    VariableAlias? defaultValue,
+  ) => call(defaultValue: defaultValue);
+
+  @override
+  /// Creates a new instance with the provided field values.
+  /// Passing `null` to a nullable field nullifies it, while `null` for a non-nullable field is ignored. To update a single field use `ComponentPropertyDefinitionVariables(...).copyWith.fieldName(value)`.
+  ///
+  /// Example:
+  /// ```dart
+  /// ComponentPropertyDefinitionVariables(...).copyWith(id: 12, name: "My name")
+  /// ```
+  ComponentPropertyDefinitionVariables call({
+    Object? defaultValue = const $CopyWithPlaceholder(),
+  }) {
+    return ComponentPropertyDefinitionVariables(
+      defaultValue: defaultValue == const $CopyWithPlaceholder()
+          ? _value.defaultValue
+          // ignore: cast_nullable_to_non_nullable
+          : defaultValue as VariableAlias?,
+    );
+  }
+}
+
+extension $ComponentPropertyDefinitionVariablesCopyWith
+    on ComponentPropertyDefinitionVariables {
+  /// Returns a callable class used to build a new instance with modified fields.
+  /// Example: `instanceOfComponentPropertyDefinitionVariables.copyWith(...)` or `instanceOfComponentPropertyDefinitionVariables.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$ComponentPropertyDefinitionVariablesCWProxy get copyWith =>
+      _$ComponentPropertyDefinitionVariablesCWProxyImpl(this);
+}
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ComponentPropertyDefinitionVariables
+_$ComponentPropertyDefinitionVariablesFromJson(Map<String, dynamic> json) =>
+    ComponentPropertyDefinitionVariables(
+      defaultValue: json['defaultValue'] == null
+          ? null
+          : VariableAlias.fromJson(
+              json['defaultValue'] as Map<String, dynamic>,
+            ),
+    );
+
+Map<String, dynamic> _$ComponentPropertyDefinitionVariablesToJson(
+  ComponentPropertyDefinitionVariables instance,
+) => <String, dynamic>{'defaultValue': ?instance.defaultValue?.toJson()};

--- a/lib/src/models/layer_trait_variables.dart
+++ b/lib/src/models/layer_trait_variables.dart
@@ -56,6 +56,8 @@ class LayerTraitVariables extends Equatable {
     this.textRangeFills = const [],
     this.effects = const [],
     this.layoutGrids = const [],
+    this.gridColumnGap,
+    this.gridRowGap,
     this.rectangleCornerRadii,
   });
 
@@ -162,6 +164,12 @@ class LayerTraitVariables extends Equatable {
   final List<VariableAlias> layoutGrids;
 
   @JsonKey(includeIfNull: false)
+  final VariableAlias? gridColumnGap;
+
+  @JsonKey(includeIfNull: false)
+  final VariableAlias? gridRowGap;
+
+  @JsonKey(includeIfNull: false)
   final RectangleCornerRadiiVariables? rectangleCornerRadii;
 
   @override
@@ -199,6 +207,8 @@ class LayerTraitVariables extends Equatable {
     textRangeFills,
     effects,
     layoutGrids,
+    gridColumnGap,
+    gridRowGap,
     rectangleCornerRadii,
   ];
 

--- a/lib/src/models/layer_trait_variables.g.dart
+++ b/lib/src/models/layer_trait_variables.g.dart
@@ -77,6 +77,10 @@ abstract class _$LayerTraitVariablesCWProxy {
 
   LayerTraitVariables layoutGrids(List<VariableAlias> layoutGrids);
 
+  LayerTraitVariables gridColumnGap(VariableAlias? gridColumnGap);
+
+  LayerTraitVariables gridRowGap(VariableAlias? gridRowGap);
+
   LayerTraitVariables rectangleCornerRadii(
     RectangleCornerRadiiVariables? rectangleCornerRadii,
   );
@@ -122,6 +126,8 @@ abstract class _$LayerTraitVariablesCWProxy {
     List<VariableAlias> textRangeFills,
     List<VariableAlias> effects,
     List<VariableAlias> layoutGrids,
+    VariableAlias? gridColumnGap,
+    VariableAlias? gridRowGap,
     RectangleCornerRadiiVariables? rectangleCornerRadii,
   });
 }
@@ -264,6 +270,14 @@ class _$LayerTraitVariablesCWProxyImpl implements _$LayerTraitVariablesCWProxy {
       call(layoutGrids: layoutGrids);
 
   @override
+  LayerTraitVariables gridColumnGap(VariableAlias? gridColumnGap) =>
+      call(gridColumnGap: gridColumnGap);
+
+  @override
+  LayerTraitVariables gridRowGap(VariableAlias? gridRowGap) =>
+      call(gridRowGap: gridRowGap);
+
+  @override
   LayerTraitVariables rectangleCornerRadii(
     RectangleCornerRadiiVariables? rectangleCornerRadii,
   ) => call(rectangleCornerRadii: rectangleCornerRadii);
@@ -310,6 +324,8 @@ class _$LayerTraitVariablesCWProxyImpl implements _$LayerTraitVariablesCWProxy {
     Object? textRangeFills = const $CopyWithPlaceholder(),
     Object? effects = const $CopyWithPlaceholder(),
     Object? layoutGrids = const $CopyWithPlaceholder(),
+    Object? gridColumnGap = const $CopyWithPlaceholder(),
+    Object? gridRowGap = const $CopyWithPlaceholder(),
     Object? rectangleCornerRadii = const $CopyWithPlaceholder(),
   }) {
     return LayerTraitVariables(
@@ -459,6 +475,14 @@ class _$LayerTraitVariablesCWProxyImpl implements _$LayerTraitVariablesCWProxy {
           ? _value.layoutGrids
           // ignore: cast_nullable_to_non_nullable
           : layoutGrids as List<VariableAlias>,
+      gridColumnGap: gridColumnGap == const $CopyWithPlaceholder()
+          ? _value.gridColumnGap
+          // ignore: cast_nullable_to_non_nullable
+          : gridColumnGap as VariableAlias?,
+      gridRowGap: gridRowGap == const $CopyWithPlaceholder()
+          ? _value.gridRowGap
+          // ignore: cast_nullable_to_non_nullable
+          : gridRowGap as VariableAlias?,
       rectangleCornerRadii: rectangleCornerRadii == const $CopyWithPlaceholder()
           ? _value.rectangleCornerRadii
           // ignore: cast_nullable_to_non_nullable
@@ -618,6 +642,12 @@ LayerTraitVariables _$LayerTraitVariablesFromJson(
           ?.map((e) => VariableAlias.fromJson(e as Map<String, dynamic>))
           .toList() ??
       [],
+  gridColumnGap: json['gridColumnGap'] == null
+      ? null
+      : VariableAlias.fromJson(json['gridColumnGap'] as Map<String, dynamic>),
+  gridRowGap: json['gridRowGap'] == null
+      ? null
+      : VariableAlias.fromJson(json['gridRowGap'] as Map<String, dynamic>),
   rectangleCornerRadii: json['rectangleCornerRadii'] == null
       ? null
       : RectangleCornerRadiiVariables.fromJson(
@@ -663,5 +693,7 @@ Map<String, dynamic> _$LayerTraitVariablesToJson(
   'textRangeFills': instance.textRangeFills.map((e) => e.toJson()).toList(),
   'effects': instance.effects.map((e) => e.toJson()).toList(),
   'layoutGrids': instance.layoutGrids.map((e) => e.toJson()).toList(),
+  'gridColumnGap': ?instance.gridColumnGap?.toJson(),
+  'gridRowGap': ?instance.gridRowGap?.toJson(),
   'rectangleCornerRadii': ?instance.rectangleCornerRadii?.toJson(),
 };

--- a/tool/types.txt
+++ b/tool/types.txt
@@ -101,6 +101,7 @@ Component
 ComponentNode
 ComponentProperty
 ComponentPropertyDefinition
+ComponentPropertyDefinitionVariables
 ComponentPropertyVariables
 ComponentSet
 ComponentSetNode


### PR DESCRIPTION
A number of bound variables are not present in the REST API spec.

Add `ComponentPropertyDefinitionVariables` and some grid related values.