### PR TITLE
models: set hyperlink type default

### DIFF
--- a/lib/src/models/hyperlink.dart
+++ b/lib/src/models/hyperlink.dart
@@ -22,6 +22,7 @@ class Hyperlink extends Equatable {
   /// The type of hyperlink.
   ///
   /// Can be either `URL` or `NODE`.
+  @JsonKey(defaultValue: HyperlinkType.url)
   final HyperlinkType type;
 
   /// The URL that the hyperlink points to, if `type` is `URL`.

--- a/lib/src/models/hyperlink.g.dart
+++ b/lib/src/models/hyperlink.g.dart
@@ -81,7 +81,9 @@ extension $HyperlinkCopyWith on Hyperlink {
 // **************************************************************************
 
 Hyperlink _$HyperlinkFromJson(Map<String, dynamic> json) => Hyperlink(
-  type: $enumDecode(_$HyperlinkTypeEnumMap, json['type']),
+  type:
+      $enumDecodeNullable(_$HyperlinkTypeEnumMap, json['type']) ??
+      HyperlinkType.url,
   url: json['url'] as String?,
   nodeId: json['nodeID'] as String?,
 );


### PR DESCRIPTION
Add a default value for the type since the API doesn't always populate it.